### PR TITLE
Remove unused `nsp` dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"covert": "^1.1.1",
 		"editorconfig-tools": "^0.1.1",
 		"eslint": "^5.13.0",
-		"nsp": "^3.2.1",
 		"replace": "^1.0.1",
 		"semver": "^5.6.0",
 		"tape": "^4.10.0"


### PR DESCRIPTION
`has` is a micro package just calling `Object.prototype.hasOwnProperty` so pull out the single production dependancy for the package.

Also removed `ncp` as it is no longer maintained https://blog.npmjs.org/post/175511531085/the-node-security-platform-service-is-shutting 