### PR TITLE
[New] use `badStringifier`‑based RegExp detection

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,16 @@
 	"extends": "@ljharb",
 
 	"rules": {
-		"id-length": [1]
-	}
+		"id-length": [1],
+		"operator-linebreak": [2, "before"],
+	},
+
+	"overrides": [
+		{
+			"files": ["test/**/*.js"],
+			"globals": {
+				"Proxy": false,
+			},
+		},
+	],
 }

--- a/index.js
+++ b/index.js
@@ -1,39 +1,49 @@
 'use strict';
 
-var has = require('has');
-var regexExec = RegExp.prototype.exec;
-var gOPD = Object.getOwnPropertyDescriptor;
+var hasSymbols = require('has-symbols')();
+var hasToStringTag = hasSymbols && typeof Symbol.toStringTag === 'symbol';
+var regexExec;
+var isRegexMarker;
+var badStringifier;
 
-var tryRegexExecCall = function tryRegexExec(value) {
-	try {
-		var lastIndex = value.lastIndex;
-		value.lastIndex = 0; // eslint-disable-line no-param-reassign
+if (hasToStringTag) {
+	regexExec = Function.call.bind(RegExp.prototype.exec);
+	isRegexMarker = {};
 
-		regexExec.call(value);
-		return true;
-	} catch (e) {
-		return false;
-	} finally {
-		value.lastIndex = lastIndex; // eslint-disable-line no-param-reassign
+	var throwRegexMarker = function () {
+		throw isRegexMarker;
+	};
+	badStringifier = {
+		toString: throwRegexMarker,
+		valueOf: throwRegexMarker
+	};
+
+	if (typeof Symbol.toPrimitive === 'symbol') {
+		badStringifier[Symbol.toPrimitive] = throwRegexMarker;
 	}
-};
+}
+
 var toStr = Object.prototype.toString;
 var regexClass = '[object RegExp]';
-var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
 
-module.exports = function isRegex(value) {
-	if (!value || typeof value !== 'object') {
-		return false;
+module.exports = hasToStringTag
+	// eslint-disable-next-line consistent-return
+	? function isRegex(value) {
+		if (!value || typeof value !== 'object') {
+			return false;
+		}
+
+		try {
+			regexExec(value, badStringifier);
+		} catch (e) {
+			return e === isRegexMarker;
+		}
 	}
-	if (!hasToStringTag) {
+	: function isRegex(value) {
+		// In older browsers, typeof regex incorrectly returns 'function'
+		if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+			return false;
+		}
+
 		return toStr.call(value) === regexClass;
-	}
-
-	var descriptor = gOPD(value, 'lastIndex');
-	var hasLastIndexDataProperty = descriptor && has(descriptor, 'value');
-	if (!hasLastIndexDataProperty) {
-		return false;
-	}
-
-	return tryRegexExecCall(value);
-};
+	};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"expression"
 	],
 	"dependencies": {
-		"has": "^1.0.3"
+		"has-symbols": "^1.0.1"
 	},
 	"devDependencies": {
 		"@ljharb/eslint-config": "^17.1.0",
@@ -46,6 +46,7 @@
 		"covert": "^1.1.1",
 		"eclint": "^2.8.1",
 		"eslint": "^7.1.0",
+		"foreach": "^2.0.5",
 		"safe-publish-latest": "^1.1.4",
 		"tape": "^5.0.1"
 	},

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var hasSymbols = require('has-symbols')();
+var hasToStringTag = hasSymbols && typeof Symbol.toStringTag === 'symbol';
+var forEach = require('foreach');
 var test = require('tape');
 var isRegex = require('..');
-var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
 
 test('not regexes', function (t) {
 	t.notOk(isRegex(), 'undefined is not regex');
@@ -51,6 +53,51 @@ test('does not mutate regexes', function (t) {
 		st.equal(regex.lastIndex, 3, 'lastIndex is 3');
 		st.ok(isRegex(regex), 'is regex');
 		st.equal(regex.lastIndex, 3, 'lastIndex is 3 after isRegex');
+		st.end();
+	});
+
+	t.end();
+});
+
+test('does not perform operations observable to Proxies', { skip: typeof Proxy !== 'function' }, function (t) {
+	var Handler = function () {
+		this.trapCalls = 0;
+	};
+
+	forEach([
+		'defineProperty',
+		'deleteProperty',
+		'get',
+		'getOwnPropertyDescriptor',
+		'getPrototypeOf',
+		'has',
+		'isExtensible',
+		'ownKeys',
+		'preventExtensions',
+		'set',
+		'setPrototypeOf'
+	], function (trapName) {
+		Handler.prototype[trapName] = function () {
+			this.trapCalls += 1;
+			return Reflect[trapName].apply(Reflect, arguments);
+		};
+	});
+
+	t.test('proxy of object', function (st) {
+		var handler = new Handler();
+		var proxy = new Proxy({ lastIndex: 0 }, handler);
+
+		st.equal(isRegex(proxy), false, 'proxy of plain object is not regex');
+		st.equal(handler.trapCalls, 0, 'no proxy traps were triggered');
+		st.end();
+	});
+
+	t.test('proxy of RegExp instance', function (st) {
+		var handler = new Handler();
+		var proxy = new Proxy(/a/, handler);
+
+		st.equal(isRegex(proxy), false, 'proxy of RegExp instance is not regex');
+		st.equal(handler.trapCalls, 0, 'no proxy traps were triggered');
 		st.end();
 	});
 


### PR DESCRIPTION
This is based on what I did in <https://github.com/inspect-js/is-callable/pull/54> for `is‑callable`.